### PR TITLE
Add per-entry pipeline status tracking with downstream callback support

### DIFF
--- a/api/local.settings.example.json
+++ b/api/local.settings.example.json
@@ -7,5 +7,7 @@
     "AZURE_STORAGE_CONNECTION_STRING": "",
     "MANAGERS_GROUP_NAME": "dyn-user-e5s",
     "MANAGERS_GROUP_ID": "d488d5a2-fba3-4c25-b64c-57c210284bc3",
+    "AZURE_STATUS_TABLE_NAME": "employeestatus",
+    "STATUS_UPDATE_KEY": ""
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "main": "host.json",
   "scripts": { "start": "func start", "build": "echo \"No build step\"" },
   "dependencies": {
+    "@azure/data-tables": "^13.3.0",
     "@azure/identity": "^4.5.0",
     "@azure/storage-queue": "^12.14.0",
     "undici": "^6.19.8"

--- a/api/status-update/function.json
+++ b/api/status-update/function.json
@@ -1,0 +1,6 @@
+{
+  "bindings": [
+    { "authLevel": "anonymous", "type": "httpTrigger", "direction": "in", "name": "req", "methods": ["post","options"], "route": "status-update" },
+    { "type": "http", "direction": "out", "name": "res" }
+  ]
+}

--- a/api/status-update/index.js
+++ b/api/status-update/index.js
@@ -1,0 +1,80 @@
+const { TableClient } = require("@azure/data-tables");
+
+const getConn = () => process.env.AZURE_STORAGE_CONNECTION_STRING || process.env.AzureWebJobsStorage || "";
+const getTableName = () => process.env.AZURE_STATUS_TABLE_NAME || "employeestatus";
+const getUpdateKey = () => process.env.STATUS_UPDATE_KEY || "";
+const PARTITION_KEY = "employee-entries";
+
+// Valid terminal and in-progress status values. Stage names starting with
+// "stage_" are also accepted to allow arbitrary runbook-defined stage names.
+const VALID_STATUSES = new Set(["queued", "processing", "provisioned", "failed"]);
+const isValidStatus = s => VALID_STATUSES.has(s) || /^stage_[a-z0-9_]+$/.test(s);
+
+module.exports = async function (context, req) {
+  const origin = req.headers?.origin || "*";
+  const cors = {
+    "Access-Control-Allow-Origin": origin,
+    "Vary": "Origin",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type,x-update-key",
+  };
+
+  if (req.method === "OPTIONS") { context.res = { status: 204, headers: cors }; return; }
+
+  // Shared-secret auth for Logic App / runbook callers.
+  const expectedKey = getUpdateKey();
+  const providedKey = req.headers["x-update-key"] || "";
+  if (!expectedKey || providedKey !== expectedKey) {
+    context.res = { status: 403, headers: cors, body: { ok: false, error: "Unauthorized" } };
+    return;
+  }
+
+  const { id, status, stageName, stageNumber, totalStages, statusMessage } = req.body || {};
+
+  if (!id || typeof id !== "string") {
+    context.res = { status: 400, headers: cors, body: { ok: false, error: "id required" } };
+    return;
+  }
+  if (!status || !isValidStatus(status)) {
+    context.res = { status: 400, headers: cors, body: { ok: false, error: "Invalid status value" } };
+    return;
+  }
+
+  const conn = getConn();
+  if (!conn) {
+    context.res = { status: 503, headers: cors, body: { ok: false, error: "Storage not configured" } };
+    return;
+  }
+
+  try {
+    const table = TableClient.fromConnectionString(conn, getTableName());
+    await table.createTable().catch(() => {});
+
+    const entity = {
+      partitionKey: PARTITION_KEY,
+      rowKey: id,
+      status,
+      stageName: stageName || null,
+      stageNumber: stageNumber != null ? Number(stageNumber) : null,
+      totalStages: totalStages != null ? Number(totalStages) : null,
+      failedStage: status === "failed" ? (stageName || null) : null,
+      statusMessage: statusMessage || null,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await table.upsertEntity(entity, "Replace");
+
+    context.res = {
+      status: 200,
+      headers: { "Content-Type": "application/json; charset=utf-8", ...cors },
+      body: { ok: true, id, status },
+    };
+  } catch (error) {
+    context.log.error("Status update failed", error?.message);
+    context.res = {
+      status: 500,
+      headers: { "Content-Type": "application/json; charset=utf-8", ...cors },
+      body: { ok: false, error: "Status update failed" },
+    };
+  }
+};

--- a/api/status/function.json
+++ b/api/status/function.json
@@ -1,0 +1,6 @@
+{
+  "bindings": [
+    { "authLevel": "anonymous", "type": "httpTrigger", "direction": "in", "name": "req", "methods": ["get","options"], "route": "status" },
+    { "type": "http", "direction": "out", "name": "res" }
+  ]
+}

--- a/api/status/index.js
+++ b/api/status/index.js
@@ -1,0 +1,83 @@
+const { TableClient } = require("@azure/data-tables");
+
+const getConn = () => process.env.AZURE_STORAGE_CONNECTION_STRING || process.env.AzureWebJobsStorage || "";
+const getTableName = () => process.env.AZURE_STATUS_TABLE_NAME || "employeestatus";
+const PARTITION_KEY = "employee-entries";
+
+function getPrincipal(req) {
+  try {
+    const raw = req.headers["x-ms-client-principal"];
+    if (!raw) return null;
+    return JSON.parse(Buffer.from(raw, "base64").toString("utf8"));
+  } catch { return null; }
+}
+function isAdmin(p) { return Boolean(p?.userRoles?.includes("it_admin")); }
+
+module.exports = async function (context, req) {
+  const origin = req.headers?.origin || "*";
+  const cors = {
+    "Access-Control-Allow-Origin": origin,
+    "Vary": "Origin",
+    "Access-Control-Allow-Methods": "GET,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+
+  if (req.method === "OPTIONS") { context.res = { status: 204, headers: cors }; return; }
+
+  const p = getPrincipal(req);
+  const bypassLocal = process.env.ALLOW_ANON_LOCAL === "true" &&
+    process.env.FUNCTIONS_CORE_TOOLS_ENVIRONMENT === "Development";
+  if (!isAdmin(p) && !bypassLocal) {
+    context.res = { status: 403, headers: cors, body: { ok: false } };
+    return;
+  }
+
+  const idsParam = req.query?.ids || "";
+  const ids = idsParam.split(",").map(s => s.trim()).filter(Boolean);
+  if (!ids.length) {
+    context.res = { status: 400, headers: cors, body: { ok: false, error: "No ids provided" } };
+    return;
+  }
+
+  const conn = getConn();
+  if (!conn) {
+    context.res = { status: 503, headers: cors, body: { ok: false, error: "Storage not configured" } };
+    return;
+  }
+
+  try {
+    const table = TableClient.fromConnectionString(conn, getTableName());
+    await table.createTable().catch(() => {});
+
+    const results = {};
+    await Promise.all(ids.map(async id => {
+      try {
+        const entity = await table.getEntity(PARTITION_KEY, id);
+        results[id] = {
+          status: entity.status,
+          stageName: entity.stageName || null,
+          stageNumber: entity.stageNumber != null ? Number(entity.stageNumber) : null,
+          totalStages: entity.totalStages != null ? Number(entity.totalStages) : null,
+          failedStage: entity.failedStage || null,
+          statusMessage: entity.statusMessage || null,
+          updatedAt: entity.updatedAt || null,
+        };
+      } catch {
+        // Entity not yet written by downstream — entry is still queued
+      }
+    }));
+
+    context.res = {
+      status: 200,
+      headers: { "Content-Type": "application/json; charset=utf-8", ...cors },
+      body: { ok: true, statuses: results },
+    };
+  } catch (error) {
+    context.log.error("Status read failed", error?.message);
+    context.res = {
+      status: 500,
+      headers: { "Content-Type": "application/json; charset=utf-8", ...cors },
+      body: { ok: false, error: "Status read failed" },
+    };
+  }
+};

--- a/client/src/FormApp.jsx
+++ b/client/src/FormApp.jsx
@@ -6,6 +6,30 @@ const API = {
   lists: '/api/lists',
   submitAll: '/api/submit-all',
   health: '/api/health',
+  status: '/api/status',
+};
+
+// Statuses that mean the entry is actively moving through the pipeline and
+// should be polled for updates.
+const IN_FLIGHT_STATUSES = new Set(['queued', 'processing', 'provisioned']);
+const isInFlight = s => IN_FLIGHT_STATUSES.has(s) || /^stage_/.test(s || '');
+
+// Statuses that block re-submission (already in the pipeline or done).
+const isSubmitted = s => s && s !== 'pending' && s !== 'failed';
+
+const STATUS_META = {
+  pending:     { label: 'Pending',     color: '#6b7280' },
+  queued:      { label: 'Queued',      color: '#3b82f6' },
+  processing:  { label: 'Processing',  color: '#f59e0b' },
+  provisioned: { label: 'Provisioned', color: '#10b981' },
+  failed:      { label: 'Failed',      color: '#ef4444' },
+};
+
+const getStatusMeta = status => {
+  if (!status || status === 'pending') return STATUS_META.pending;
+  if (STATUS_META[status]) return STATUS_META[status];
+  if (/^stage_/.test(status)) return { label: status.replace(/^stage_/, '').replace(/_/g, ' '), color: '#f59e0b' };
+  return { label: status, color: '#6b7280' };
 };
 
 // LocalStorage key for persisting saved employee entries between sessions.
@@ -253,12 +277,50 @@ function ManagerComboBox({ managers, value, onSelect, error }) {
   );
 }
 
+function StatusBadge({ entry }) {
+  const status = entry._meta?.status || 'pending';
+  const meta = getStatusMeta(status);
+  const stageName = entry._meta?.stageName;
+  const stageNumber = entry._meta?.stageNumber;
+  const totalStages = entry._meta?.totalStages;
+  const statusMessage = entry._meta?.statusMessage;
+
+  const label = stageName
+    ? stageName
+    : meta.label;
+
+  const progress = stageNumber != null && totalStages != null
+    ? ` (${stageNumber}/${totalStages})`
+    : '';
+
+  return (
+    <span
+      title={statusMessage || label}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '2px 8px',
+        borderRadius: 12,
+        fontSize: 11,
+        fontWeight: 600,
+        background: `${meta.color}22`,
+        color: meta.color,
+        border: `1px solid ${meta.color}55`,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span style={{ width: 7, height: 7, borderRadius: '50%', background: meta.color, display: 'inline-block', flexShrink: 0 }} />
+      {label}{progress}
+    </span>
+  );
+}
+
 function EntriesTable({ entries, onEdit, onDelete }) {
   if (!entries.length) {
     return <div className="muted" id="empty-state">No entries yet. Submit the form to see items here.</div>;
   }
 
-  // Render a compact summary of saved entries with edit/delete controls.
   return (
     <div id="entries-wrap">
       <table aria-describedby="entries-count">
@@ -272,39 +334,47 @@ function EntriesTable({ entries, onEdit, onDelete }) {
             <th>Start Date</th>
             <th>Full Time</th>
             <th>Manager</th>
+            <th>Status</th>
             <th style={{ width: 180 }}>Actions</th>
           </tr>
         </thead>
 
         <tbody>
-          {entries.map(entry => (
-            <tr key={entry.id}>
-              <td>{entry.firstName}</td>
-              <td>{entry.lastName}</td>
-              <td>{entry.title}</td>
-              <td>{entry.department}</td>
-              <td>
-                <span className="chip">{entry.businessUnit}</span>
-              </td>
-              <td>
-                <span className="chip">{formatStartDate(entry.startDate)}</span>
-              </td>
-              <td>
-                <span className="chip">{entry.fullTime ? 'Yes' : 'No'}</span>
-              </td>
-              <td>
-                <span className="chip">{entry.managerName || entry.managerUpn || entry.managerId}</span>
-              </td>
-              <td>
-                <button type="button" onClick={() => onEdit(entry.id)}>
-                  Edit
-                </button>{' '}
-                <button type="button" onClick={() => onDelete(entry.id)}>
-                  Delete
-                </button>
-              </td>
-            </tr>
-          ))}
+          {entries.map(entry => {
+            const status = entry._meta?.status || 'pending';
+            const submitted = isSubmitted(status);
+            return (
+              <tr key={entry.id}>
+                <td>{entry.firstName}</td>
+                <td>{entry.lastName}</td>
+                <td>{entry.title}</td>
+                <td>{entry.department}</td>
+                <td>
+                  <span className="chip">{entry.businessUnit}</span>
+                </td>
+                <td>
+                  <span className="chip">{formatStartDate(entry.startDate)}</span>
+                </td>
+                <td>
+                  <span className="chip">{entry.fullTime ? 'Yes' : 'No'}</span>
+                </td>
+                <td>
+                  <span className="chip">{entry.managerName || entry.managerUpn || entry.managerId}</span>
+                </td>
+                <td>
+                  <StatusBadge entry={entry} />
+                </td>
+                <td>
+                  <button type="button" onClick={() => onEdit(entry.id)} disabled={submitted}>
+                    Edit
+                  </button>{' '}
+                  <button type="button" onClick={() => onDelete(entry.id)}>
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -337,8 +407,9 @@ export default function FormApp() {
   const [entries, setEntries] = useLocalStorage(STORAGE_KEY, []);
   const [toast, setToast] = useState('');
 
+  // Count entries that can still be submitted (pending or previously failed).
   const unsubmitted = useMemo(
-    () => entries.filter(entry => !entry._meta?.submittedAt).length,
+    () => entries.filter(entry => !isSubmitted(entry._meta?.status)).length,
     [entries],
   );
 
@@ -375,6 +446,62 @@ export default function FormApp() {
       alive = false;
     };
   }, []);
+
+  // Poll /api/status for any entries currently in the pipeline. Runs every
+  // 30s while the page is visible; skips when there's nothing to watch.
+  useEffect(() => {
+    let alive = true;
+    const controllerRef = { current: null };
+
+    const poll = async () => {
+      const toWatch = entries.filter(e => isInFlight(e._meta?.status));
+      if (!toWatch.length) return;
+
+      controllerRef.current?.abort();
+      const ac = new AbortController();
+      controllerRef.current = ac;
+
+      try {
+        const ids = toWatch.map(e => e.id).join(',');
+        const response = await fetch(`${API.status}?ids=${encodeURIComponent(ids)}`, { signal: ac.signal });
+        if (!response.ok || !alive) return;
+
+        const data = await response.json();
+        if (!data?.statuses) return;
+
+        setEntries(previous =>
+          previous.map(entry => {
+            const update = data.statuses[entry.id];
+            if (!update) return entry;
+            return {
+              ...entry,
+              _meta: {
+                ...entry._meta,
+                status: update.status,
+                stageName: update.stageName,
+                stageNumber: update.stageNumber,
+                totalStages: update.totalStages,
+                failedStage: update.failedStage,
+                statusMessage: update.statusMessage,
+                statusUpdatedAt: update.updatedAt,
+              },
+            };
+          }),
+        );
+      } catch {
+        // Polling errors are silent; next interval will retry.
+      }
+    };
+
+    poll();
+    const id = setInterval(() => { if (!document.hidden && alive) poll(); }, 30000);
+
+    return () => {
+      alive = false;
+      clearInterval(id);
+      controllerRef.current?.abort();
+    };
+  }, [entries]);
 
   const setField = (key, value) => setForm(previous => ({ ...previous, [key]: value }));
 
@@ -447,7 +574,7 @@ export default function FormApp() {
           )
         : [
             ...previous,
-            { ...form, id: uuid(), _meta: { savedAt: now, submittedAt: null, schema: 4 } },
+            { ...form, id: uuid(), _meta: { savedAt: now, submittedAt: null, status: 'pending', schema: 5 } },
           ],
     );
 
@@ -515,10 +642,9 @@ export default function FormApp() {
     URL.revokeObjectURL(anchor.href);
   };
 
-  // Submit all saved entries to the API, prune accepted ones locally, and
-  // surface a toast summarizing the result.
+  // Submit pending/failed entries to the API and update their status in place.
   const submitAll = async () => {
-    const toSubmit = entries;
+    const toSubmit = entries.filter(e => !isSubmitted(e._meta?.status));
     if (!toSubmit.length) {
       showToast('Nothing to submit.');
       return;
@@ -538,14 +664,41 @@ export default function FormApp() {
       return;
     }
 
+    const now = new Date().toISOString();
     const acceptedIds = new Set((result.accepted || []).map(x => x.id));
-    const failed = result.failed || [];
+    const failedIds = new Set((result.failed || []).map(x => x.id));
 
-    setEntries(previous => previous.filter(entry => !acceptedIds.has(entry.id)));
+    setEntries(previous =>
+      previous.map(entry => {
+        if (acceptedIds.has(entry.id)) {
+          return {
+            ...entry,
+            _meta: {
+              ...entry._meta,
+              submittedAt: now,
+              status: 'queued',
+              stageName: null,
+              stageNumber: null,
+              totalStages: null,
+              failedStage: null,
+              statusMessage: null,
+              statusUpdatedAt: now,
+            },
+          };
+        }
+        if (failedIds.has(entry.id)) {
+          return {
+            ...entry,
+            _meta: { ...entry._meta, status: 'failed', statusMessage: 'Queue submission failed' },
+          };
+        }
+        return entry;
+      }),
+    );
 
     const ok = acceptedIds.size;
-    const fail = failed.length;
-    showToast(fail ? `Submitted ${ok}, ${fail} failed.` : `Submitted ${ok} and cleared.`);
+    const fail = failedIds.size;
+    showToast(fail ? `Queued ${ok}, ${fail} failed.` : `Queued ${ok}.`);
   };
 
   return (


### PR DESCRIPTION
- New /api/status endpoint: reads per-entry status from Azure Table Storage (polled by the frontend every 30s for in-flight entries)
- New /api/status-update endpoint: called by Logic App / runbooks via shared secret (x-update-key header) to write stage progress, completion, or failure for each entry by its UUID
- Add @azure/data-tables dependency; add AZURE_STATUS_TABLE_NAME and STATUS_UPDATE_KEY to local.settings.example.json
- FormApp: entries no longer deleted on queue acceptance — status advances through pending → queued → stage_* → provisioned (or failed); Edit is disabled for in-flight/completed entries; Submit All skips already-queued entries; StatusBadge component shows color-coded stage name and progress

https://claude.ai/code/session_01NJrfMJW5mnPoRA6ynFyhRX